### PR TITLE
Remove sprockets-helpers require

### DIFF
--- a/lib/sprockets/sass/functions.rb
+++ b/lib/sprockets/sass/functions.rb
@@ -1,5 +1,4 @@
 require "sass"
-require "sprockets-helpers"
 
 module Sprockets
   module Sass

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "sprockets"
 require "sprockets-sass"
 require "compass"
 require "construct"
+require "sprockets-helpers"
 
 Compass.configuration do |compass|
   compass.line_comments = false


### PR DESCRIPTION
sprockets-sass works great without sprockets-helpers, as long as the helper methods are defined. I've been using [sinatra-sprockets](https://github.com/thegorgon/sinatra-sprockets), which I prefer to sprockets-helpers because it includes the rake task to precompile.

I would love to work with you and @thegorgon to make sprockets work better in non-rails apps. Ideally, sinatra-sprockets could just use sprockets-helpers.
