### PR TITLE
do not initialize super if it is already initialized to avoid tilt warning

### DIFF
--- a/lib/sprockets/sass/sass_template.rb
+++ b/lib/sprockets/sass/sass_template.rb
@@ -15,7 +15,7 @@ module Sprockets
       
       # Add the Sass functions if they haven't already been added.
       def initialize_engine
-        super
+        super unless self.class.superclass.engine_initialized?
         
         if Sass.add_sass_functions
           require 'sprockets/sass/functions'

--- a/spec/sprockets-sass_spec.rb
+++ b/spec/sprockets-sass_spec.rb
@@ -286,4 +286,22 @@ describe Sprockets::Sass do
 
     Sprockets::Sass::Compressor.new.compress(css).should == "div{color:red}\n"
   end
+
+  describe Sprockets::Sass::SassTemplate do
+    describe "initialize_engine" do
+      let(:template) { Sprockets::Sass::SassTemplate.new{} }
+
+      it "initializes super if super is uninitinalized" do
+        Tilt::SassTemplate.stub(:engine_initialized?).and_return false
+        template.should_receive(:require_template_library) # called from Tilt::SassTemplate.initialize
+        template.initialize_engine
+      end
+
+      it "does not initializes super if super is initinalized to silence warnings" do
+        Tilt::SassTemplate.stub(:engine_initialized?).and_return true
+        template.should_not_receive(:require_template_library) # called from Tilt::SassTemplate.initialize
+        template.initialize_engine
+      end
+    end
+  end
 end


### PR DESCRIPTION
WARN: tilt autoloading 'sass' in a non thread-safe way; explicit require 'sass' suggested."

always appears even if sass was already required, since initialize_engine always called super
