### PR TITLE
added font_path and font_url

### DIFF
--- a/lib/sprockets/sass/functions.rb
+++ b/lib/sprockets/sass/functions.rb
@@ -73,6 +73,42 @@ module Sprockets
         end
         ::Sass::Script::String.new "url(#{image_path(source, options)})"
       end
+
+      # Using Sprockets::Helpers#font_path, return the full path
+      # for the given +source+ as a Sass String. This supports keyword
+      # arguments that mirror the +options+.
+      #
+      # === Examples
+      #
+      #   background: url(font-path("font.ttf"));                // background: url("/assets/font.ttf");
+      #   background: url(font-path("font.ttf", $digest: true)); // background: url("/assets/font-27a8f1f96afd8d4c67a59eb9447f45bd.ttf");
+      #
+      def font_path(source, options = {})
+        ::Sass::Script::String.new sprockets_context.font_path(source.value, map_options(options)).to_s, :string
+      end
+      
+      # Using Sprockets::Helpers#image_path, return the url CSS
+      # for the given +source+ as a Sass String. This supports keyword
+      # arguments that mirror the +options+.
+      #
+      # === Examples
+      #
+      #   background: font-url("font.ttf");                  // background: url("/assets/font.ttf");
+      #   background: font-url("image.jpg", $digest: true);  // background: url("/assets/font-27a8f1f96afd8d4c67a59eb9447f45bd.ttf");
+      #
+      def font_url(source, options = {}, cache_buster = nil)
+        # Work with the Compass #image_url API
+        if options.respond_to? :value
+          case options.value
+          when true
+            return font_path source
+          else
+            options = {}
+          end
+        end
+        ::Sass::Script::String.new "url(#{font_path(source, options)})"
+      end
+
       
       # Using Sprockets::Context#asset_data_uri return a Base64-encoded `data:`
       # URI with the contents of the asset at the specified path.
@@ -109,7 +145,7 @@ module Sass::Script::Functions
   
   # Hack to ensure previous API declarations (by Compass or whatever)
   # don't take precedence.
-  [:asset_path, :asset_url, :image_path, :image_url, :asset_data_uri].each do |method|
+  [:asset_path, :asset_url, :image_path, :image_url, :font_path, :font_url, :asset_data_uri].each do |method|
     defined?(@signatures) && @signatures.delete(method)
   end
   
@@ -121,5 +157,9 @@ module Sass::Script::Functions
   declare :image_url,      [:source], :var_kwargs => true
   declare :image_url,      [:source, :only_path]
   declare :image_url,      [:source, :only_path, :cache_buster]
+  declare :font_path,      [:source], :var_kwargs => true
+  declare :font_url,       [:source], :var_kwargs => true
+  declare :font_url,       [:source, :only_path]
+  declare :font_url,       [:source, :only_path, :cache_buster]
   declare :asset_data_uri, [:source]
 end

--- a/spec/sprockets-sass_spec.rb
+++ b/spec/sprockets-sass_spec.rb
@@ -249,6 +249,19 @@ describe Sprockets::Sass do
     @env['image_path_options.css'].to_s.should =~ %r(body \{\n  background: url\("/themes/image-[0-9a-f]+.jpg"\); \}\n)
     @env['image_url_options.css'].to_s.should =~ %r(body \{\n  background: url\("/themes/image-[0-9a-f]+.jpg"\); \}\n)
   end
+
+  it 'adds the #font_path helper' do
+    @assets.file 'font_path.css.scss', %(@font-face { src: url(font-path("font.ttf")); })
+    @assets.file 'font_url.css.scss', %(@font-face { src: font-url("font.ttf"); })
+    @assets.file 'font_path_options.css.scss', %(@font-face { src: url(font-path("font.ttf", $digest: true, $prefix: "/themes")); })
+    @assets.file 'font_url_options.css.scss', %(@font-face { src: font-url("font.ttf", $digest: true, $prefix: "/themes"); })
+    @assets.file 'font.ttf'
+    
+    @env['font_path.css'].to_s.should == %(@font-face {\n  src: url("/assets/font.ttf"); }\n)
+    @env['font_url.css'].to_s.should == %(@font-face {\n  src: url("/assets/font.ttf"); }\n)
+    @env['font_path_options.css'].to_s.should =~ %r(@font-face \{\n  src: url\("/themes/font-[0-9a-f]+.ttf"\); \}\n)
+    @env['font_url_options.css'].to_s.should =~ %r(@font-face \{\n  src: url\("/themes/font-[0-9a-f]+.ttf"\); \}\n)
+  end
   
   it 'adds the #asset_data_uri helper' do
     @assets.file 'asset_data_uri.css.scss', %(body { background: asset-data-uri("image.jpg"); })
@@ -266,6 +279,17 @@ describe Sprockets::Sass do
     @env['image_path.css'].to_s.should == %(body {\n  background: url("/assets/image.jpg"); }\n)
     @env['image_url.css'].to_s.should == %(body {\n  background: url("/assets/image.jpg"); }\n)
     @env['cache_buster.css'].to_s.should == %(body {\n  background: url("/assets/image.jpg"); }\n)
+  end
+
+  it "mirrors Compass's #font_url helper" do
+    @assets.file 'font_path.css.scss', %(@font-face { src: url(font-url("font.ttf", true)); })
+    @assets.file 'font_url.css.scss', %(@font-face { src: font-url("font.ttf", false); })
+    @assets.file 'font_cache_buster.css.scss', %(@font-face { src: font-url("font.ttf", false, true); })
+    @assets.file 'font.ttf'
+    
+    @env['font_path.css'].to_s.should == %(@font-face {\n  src: url("/assets/font.ttf"); }\n)
+    @env['font_url.css'].to_s.should == %(@font-face {\n  src: url("/assets/font.ttf"); }\n)
+    @env['font_cache_buster.css'].to_s.should == %(@font-face {\n  src: url("/assets/font.ttf"); }\n)
   end
   
   it "mirrors Sass::Rails's #asset_path helpers" do


### PR DESCRIPTION
I added `font_path` to sprockets-helpers (see here: https://github.com/petebrowne/sprockets-helpers/pull/5).

This pull request uses that to provide `font-url` to Sass. The reason I want this is that I'm trying to use font-awesome, and the Sass files I have for it use `font-url`.

Obviously, the helpers change needs to be available for this to work (in testing, I cheated with the Gemfile).
