### PR TITLE
Fix a missing require

### DIFF
--- a/lib/sprockets/sass.rb
+++ b/lib/sprockets/sass.rb
@@ -1,3 +1,4 @@
+require 'sprockets'
 require 'sprockets/sass/version'
 require 'sprockets/sass/sass_template'
 require 'sprockets/sass/scss_template'


### PR DESCRIPTION
Require sprockets so that, when the gem is called in a Rails app, register_engine functions properly
