### PR TITLE
Remove an unneccessry check that prevented some assets from being imported properly

### DIFF
--- a/lib/sprockets/sass/importer.rb
+++ b/lib/sprockets/sass/importer.rb
@@ -5,15 +5,15 @@ module Sprockets
   module Sass
     class Importer < ::Sass::Importers::Base
       GLOB = /\*|\[.+\]/
-      
+
       # Reference to the Sprockets context
       attr_reader :context
-      
-      # 
+
+      #
       def initialize(context)
         @context = context
       end
-      
+
       # @see Sass::Importers::Base#find_relative
       def find_relative(path, base_path, options)
         if path =~ GLOB
@@ -22,7 +22,7 @@ module Sprockets
           engine_from_path(path, base_path, options)
         end
       end
-      
+
       # @see Sass::Importers::Base#find
       def find(path, options)
         engine_from_path(path, nil, options)
@@ -47,9 +47,9 @@ module Sprockets
       def to_s
         "#{self.class.name}:#{context.pathname}"
       end
-      
+
       protected
-      
+
       # Create a Sass::Engine from the given path.
       def engine_from_path(path, base_path, options)
         pathname = resolve(path, base_path) or return nil
@@ -60,7 +60,7 @@ module Sprockets
           :importer => self
         )
       end
-      
+
       # Create a Sass::Engine that will handle importing
       # a glob of files.
       def engine_from_glob(glob, base_path, options)
@@ -76,7 +76,7 @@ module Sprockets
           :importer => self
         )
       end
-      
+
       # Finds an asset from the given path. This is where
       # we make Sprockets behave like Sass, and import partial
       # style paths.
@@ -87,17 +87,17 @@ module Sprockets
 
         nil
       end
-      
+
       # Finds all of the assets using the given glob.
       def resolve_glob(glob, base_path)
         base_path      = Pathname.new(base_path)
         path_with_glob = base_path.dirname.join(glob).to_s
-        
+
         Pathname.glob(path_with_glob).sort.select do |path|
           path != context.pathname && context.asset_requirable?(path)
         end
       end
-      
+
       # Returns all of the possible paths (including partial variations)
       # to attempt to resolve with the given path.
       def possible_files(path, base_path)
@@ -107,15 +107,15 @@ module Sprockets
         paths     = [ path, partialize_path(path) ]
 
         # Add the relative path from the root, if necessary
-        if path.relative? && base_path != root_path && path.to_s !~ /\A\.\//
+        if path.relative? && base_path != root_path
           relative_path = base_path.relative_path_from(root_path).join path
-          
+
           paths.unshift(relative_path, partialize_path(relative_path))
         end
 
         paths.compact
       end
-      
+
       # Returns the partialized version of the given path.
       # Returns nil if the path is already to a partial.
       def partialize_path(path)
@@ -123,12 +123,12 @@ module Sprockets
           Pathname.new path.to_s.sub(/([^\/]+)\Z/, '_\1')
         end
       end
-      
+
       # Returns the Sass syntax of the given path.
       def syntax(path)
         path.to_s.include?('.sass') ? :sass : :scss
       end
-      
+
       # Returns the string to be passed to the Sass engine. We use
       # Sprockets to process the file, but we remove any Sass processors
       # because we need to let the Sass::Engine handle that.

--- a/spec/sprockets-sass_spec.rb
+++ b/spec/sprockets-sass_spec.rb
@@ -86,6 +86,14 @@ describe Sprockets::Sass do
     expect(asset.to_s).to eql("body {\n  background-color: red;\n  color: blue; }\n")
   end
 
+  it 'imports deeply nested relative partials' do
+    @assets.file 'package-prime/stylesheets/main.scss', %(@import "package-dep/src/stylesheets/variables";\nbody { background-color: $background-color; color: $color; })
+    @assets.file 'package-dep/src/stylesheets/_variables.scss', %(@import "./colors";\n$background-color: red;)
+    @assets.file 'package-dep/src/stylesheets/_colors.scss', '$color: blue;'
+    asset = @env['package-prime/stylesheets/main.scss']
+    expect(asset.to_s).to eql("body {\n  background-color: red;\n  color: blue; }\n")
+  end
+
   it 'imports relative files without preceding ./' do
     @assets.file 'folder/main.css.scss', %(@import "dep-1";\n@import "subfolder/dep-2";\nbody { background-color: $background-color; color: $color; })
     @assets.file 'folder/dep-1.css.scss', '$background-color: red;'

--- a/sprockets-sass.gemspec
+++ b/sprockets-sass.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass',              '~> 3.2'
   s.add_development_dependency 'compass',           '~> 0.12'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
Importing assets relative to a file bing imported by another file (when
the relative location was not the same as for the original importing
file) didn't work as it does in sass-rails.  Added a test to catch this
case and removed an unneccessary check that was causing the error.
