### PR TITLE
Specs and fixes for nested partials with relative paths problem

### DIFF
--- a/lib/sprockets/sass/importer.rb
+++ b/lib/sprockets/sass/importer.rb
@@ -60,7 +60,7 @@ module Sprockets
         context = options[:custom][:sprockets_context]
         imports = resolve_glob(context, glob, base_path).inject('') do |imports, path|
           context.depend_on path
-          relative_path = path.relative_path_from Pathname.new(context.root_path)
+          relative_path = path.relative_path_from Pathname.new(base_path).dirname
           imports << %(@import "#{relative_path}";\n)
         end
         return nil if imports.empty?
@@ -97,7 +97,12 @@ module Sprockets
       def possible_files(context, path, base_path)
         path      = Pathname.new(path)
         base_path = Pathname.new(base_path).dirname
-        root_path = Pathname.new(context.root_path)
+
+        # Find base_path's root
+        root_path = context.environment.paths.map{|p| Pathname.new p}.select do |env_root_path|
+          base_path.to_s.start_with?( env_root_path.to_s )
+        end.first || context.root_path
+
         paths     = [ path, partialize_path(path) ]
 
         # Add the relative path from the root, if necessary

--- a/spec/sprockets-sass_spec.rb
+++ b/spec/sprockets-sass_spec.rb
@@ -145,6 +145,30 @@ describe Sprockets::Sass do
     expect(asset.to_s).to eql("body {\n  color: blue; }\n")
   end
 
+  it 'imports nested partials with relative path from the assets load path' do
+    vendor = @root.directory 'vendor'
+    @env.append_path vendor.to_s
+
+    @assets.file 'folder/main.css.scss', %(@import "dep";\nbody { color: $color; })
+    vendor.file 'dep.css.scss', '@import "folder1/dep1";'
+    vendor.file 'folder1/_dep1.scss', '@import "folder2/dep2";'
+    vendor.file 'folder1/folder2/_dep2.scss', '$color: blue;'
+    asset = @env['folder/main.css']
+    expect(asset.to_s).to eql("body {\n  color: blue; }\n")
+  end
+
+  it 'imports nested partials with relative path and glob from the assets load path' do
+    vendor = @root.directory 'vendor'
+    @env.append_path vendor.to_s
+
+    @assets.file 'folder/main.css.scss', %(@import "dep";\nbody { color: $color; })
+    vendor.file 'dep.css.scss', '@import "folder1/dep1";'
+    vendor.file 'folder1/_dep1.scss', '@import "folder2/*";'
+    vendor.file 'folder1/folder2/_dep2.scss', '$color: blue;'
+    asset = @env['folder/main.css']
+    expect(asset.to_s).to eql("body {\n  color: blue; }\n")
+  end
+
   it 'allows global Sass configuration' do
     Sprockets::Sass.options[:style] = :compact
     @assets.file 'main.css.scss', "body {\n  color: blue;\n}"


### PR DESCRIPTION
This fixes "File to import not found or unreadable" problem when there are several load paths, and imported partials use relative paths:
https://github.com/petebrowne/sprockets-sass/issues/27

I believe `context.root_path` is to blame:
https://github.com/petebrowne/sprockets-sass/blob/master/lib/sprockets/sass/importer.rb#L100
https://github.com/petebrowne/sprockets-sass/blob/master/lib/sprockets/sass/importer.rb#L63

There a two problems with that.

1) Once you start using several assets load paths, you essentially have several "roots" to build relative path from. 

For example, a file A in `assets/` imports a file B from `vendor/`. Now, if any @import directive in file B uses relative path, you would want to build this relative path from `vendor/`, but `context.root_path` points to `assets/`.

2) `Sprockets::Context#resolve()` treats relative paths starting with '.' or '..' as if they originated from `context.pathname.dirname` which is the actual directory where file A resides, not from `context.root_path`.
https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/context.rb#L78

Current sprockets-sass code builds relative paths from `context.root_path`, which in case of file A in `assets/` and file B in `vendor/` come in form `../vendor/`. This works only when `context.pathname.dirname` and `context.root_path` are the same. I.e. if file A is at the topmost level in `assets/`. Placing it somewhere deeper, like in `assets/folder/`, breaks things.

My patch fixes these problems by finding appropriate root_path, so a relative path built from it is resolved properly by `Sprockets::Context#resolve()`.
