### PR TITLE
Less support in sprockets >= 3.x  for SCSS and SASS files. 

### DIFF
--- a/lib/sprockets/sass/utils.rb
+++ b/lib/sprockets/sass/utils.rb
@@ -57,6 +57,12 @@ module Sprockets
           nil
         end
 
+        def get_less_class_by_version(class_name, version = version_of_sprockets)
+          constantize("Sprockets::Less::V#{version}::#{class_name}")
+        rescue
+          nil
+        end
+
         def constantize(camel_cased_word)
           names = camel_cased_word.split('::')
 

--- a/lib/sprockets/sass/v2/sass_template.rb
+++ b/lib/sprockets/sass/v2/sass_template.rb
@@ -126,7 +126,7 @@ module Sprockets
           else
             css
           end
-
+          
           #  Tilt::SassTemplate.new(filename, sass_options(filename, context)).render(self)
         rescue => e
           # Annotates exception message with parse line number

--- a/lib/sprockets/sass/v3/importer.rb
+++ b/lib/sprockets/sass/v3/importer.rb
@@ -124,7 +124,7 @@ module Sprockets
         def handle_complex_process_result(context, result, processors)
           data = result[:data] if result.key?(:data)
           context.metadata.merge!(result)
-          context.metadata.delete(:data)
+          # context.metadata.delete(:data)
           if result.key?(:required)
             result[:required].each do |file|
               file_asset = context.environment.load(file)
@@ -160,7 +160,7 @@ module Sprockets
           processors.each do |processor|
             data = call_processor_input(processor, context, input, processors)
           end
-          
+
           data
         end
 

--- a/lib/sprockets/sass/v3/importer.rb
+++ b/lib/sprockets/sass/v3/importer.rb
@@ -6,7 +6,7 @@ module Sprockets
       # class used for importing files from SCCS and SASS files
       class Importer < Sprockets::Sass::V2::Importer
         GLOB = /\*|\[.+\]/
-        
+
       protected
 
         def resolve_path_with_load_paths(context, path, root_path, file)
@@ -160,7 +160,7 @@ module Sprockets
           processors.each do |processor|
             data = call_processor_input(processor, context, input, processors)
           end
-
+          
           data
         end
 
@@ -194,6 +194,8 @@ module Sprockets
         end
 
         def evaluate_path_from_context(context, path, processors)
+          less_processor = Sprockets::Sass::Utils.get_less_class_by_version('LessTemplate')
+          processors = [less_processor] if less_processor && path.include?('.less')
           process(processors, context, path)
         end
 


### PR DESCRIPTION
Hello, i have recently added support for sprockets 3.x for Less too in this pull request  https://github.com/lloeki/sprockets-less/pull/5

I recently discovered that with Sprockets 2.x it is possible to use Less inside SCSS or SASS files.
( I mean requiring Less files or importing them inside SCSS or SASS files ) 
This adds this support to sprockets >=  3.x 

Without this changes , trying to use LESS inside SASS or SCSS will result in a error.

I tested this and now is working ok. ALthough the pull request for Sprockets-Less is not yet merged into master, this won't affect anything, because if the class is not available will simply skip the step of 
setting the correct processor for LESS. 

I am not sure how to detect other processors for LESS but i will try to find a better way in maybe other pull request. Currently i am checking if the class exists. 

Please let me know what you think
