### PR TITLE
[BuG fix] V3 importer was not detecting engines registered on a file extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - gem install bundler
 rvm:
-- 2.0.0
-- 2.1.5
 - 2.2.2
 - 2.2.3
 - 2.3.1

--- a/lib/sprockets/sass/v2/importer.rb
+++ b/lib/sprockets/sass/v2/importer.rb
@@ -171,12 +171,12 @@ module Sprockets
           []
         end
 
-        def get_engines_from_attributes(attributes)
+        def get_engines_from_attributes(context, attributes)
           attributes.engines
         end
 
         def get_all_processors_for_evaluate(context, content_type, attributes, path)
-          engines = get_engines_from_attributes(attributes)
+          engines = get_engines_from_attributes(context, attributes)
           preprocessors = get_context_preprocessors(context, content_type)
           additional_transformers = get_context_transformers(context, content_type, path)
           additional_transformers.reverse + preprocessors + engines.reverse

--- a/lib/sprockets/sass/v3/importer.rb
+++ b/lib/sprockets/sass/v3/importer.rb
@@ -125,7 +125,7 @@ module Sprockets
         def handle_complex_process_result(context, result, processors)
           data = result[:data] if result.key?(:data)
           context.metadata.merge!(result)
-          # context.metadata.delete(:data)
+          context.metadata.delete(:data)
           if result.key?(:required)
             result[:required].each do |file|
               file_asset = context.environment.load(file)

--- a/lib/sprockets/sass/v3/importer.rb
+++ b/lib/sprockets/sass/v3/importer.rb
@@ -189,7 +189,12 @@ module Sprockets
           engines = get_engines_from_attributes(context, attributes)
           preprocessors = get_context_preprocessors(context, content_type)
           additional_transformers = get_context_transformers(context, content_type, path)
-          engines.reverse + additional_transformers.reverse + preprocessors
+          postprocessors = get_context_postprocessors(context, content_type)
+          engines.reverse + preprocessors + additional_transformers.reverse  + postprocessors
+        end
+
+        def get_context_postprocessors(context, content_type)
+          context.environment.postprocessors[content_type].map { |a| a.class == Class ? a : a.class  }
         end
 
         def filter_all_processors(processors)

--- a/lib/sprockets/sass/v3/importer.rb
+++ b/lib/sprockets/sass/v3/importer.rb
@@ -6,7 +6,7 @@ module Sprockets
       # class used for importing files from SCCS and SASS files
       class Importer < Sprockets::Sass::V2::Importer
         GLOB = /\*|\[.+\]/
-        
+
       protected
 
         def resolve_path_with_load_paths(context, path, root_path, file)
@@ -124,7 +124,7 @@ module Sprockets
         def handle_complex_process_result(context, result, processors)
           data = result[:data] if result.key?(:data)
           context.metadata.merge!(result)
-          context.metadata.delete(:data)
+          # context.metadata.delete(:data)
           if result.key?(:required)
             result[:required].each do |file|
               file_asset = context.environment.load(file)

--- a/lib/sprockets/sass/v3/importer.rb
+++ b/lib/sprockets/sass/v3/importer.rb
@@ -7,7 +7,7 @@ module Sprockets
       class Importer < Sprockets::Sass::V2::Importer
         GLOB = /\*|\[.+\]/
 
-      protected
+        protected
 
         def resolve_path_with_load_paths(context, path, root_path, file)
           context.resolve(file.to_s, load_paths: context.environment.paths, base_path: root_path, accept: syntax_mime_type(path))
@@ -43,10 +43,10 @@ module Sprockets
 
         def asset_requirable?(context, path)
           pathname = begin
-                       context.resolve(path)
-                     rescue
-                       nil
-                     end
+            context.resolve(path)
+          rescue
+            nil
+          end
           return false if pathname.nil?
           stat = stat_of_pathname(context, pathname, path)
           return false unless stat && stat.file?
@@ -118,6 +118,7 @@ module Sprockets
           metadata = (input[:metadata] || {}).dup
           metadata[:data] = input[:data]
           result = processor.call(input)
+          processors.delete(processor)
           handle_process_result(context, result, processors, metadata)
         end
 
@@ -137,14 +138,14 @@ module Sprockets
         def handle_process_result(context, result, processors, metadata)
           data = nil
           case result
-            when NilClass
-              data = metadata[:data]
-            when Hash
-              data = handle_complex_process_result(context, result, processors)
-            when String
-              data = result
-            else
-              raise Error, "invalid processor return type: #{result.class}"
+          when NilClass
+            data = metadata[:data]
+          when Hash
+            data = handle_complex_process_result(context, result, processors)
+          when String
+            data = result
+          else
+            raise Error, "invalid processor return type: #{result.class}"
           end
           data
         end
@@ -156,7 +157,6 @@ module Sprockets
           path = check_path_before_process(context, path)
           data = Sprockets::Sass::Utils.read_template_file(path.to_s)
           input = build_input_for_process(context, path, data)
-
           processors.each do |processor|
             data = call_processor_input(processor, context, input, processors)
           end
@@ -174,15 +174,22 @@ module Sprockets
           additional_transformers.is_a?(Array) ? additional_transformers : [additional_transformers]
         end
 
-        def get_engines_from_attributes(_attributes)
-          []
+        def get_engines_from_attributes(context, attributes)
+          engines = []
+          attributes[2].each do |extension|
+            ext = ::Sprockets::Utils.normalize_extension(extension)
+            ext_engines = context.environment.engines[ext]
+            ext_engines = ext_engines.is_a?(Array) ? ext_engines : [ext_engines]
+            engines.concat(ext_engines)
+          end
+          engines
         end
 
         def get_all_processors_for_evaluate(context, content_type, attributes, path)
-          engines = get_engines_from_attributes(attributes)
+          engines = get_engines_from_attributes(context, attributes)
           preprocessors = get_context_preprocessors(context, content_type)
           additional_transformers = get_context_transformers(context, content_type, path)
-          additional_transformers.reverse + preprocessors + engines.reverse
+          engines.reverse + additional_transformers.reverse + preprocessors
         end
 
         def filter_all_processors(processors)

--- a/lib/sprockets/sass/v4/importer.rb
+++ b/lib/sprockets/sass/v4/importer.rb
@@ -85,6 +85,10 @@ module Sprockets
           end
         end
 
+        def get_engines_from_attributes(_attributes)
+          []
+        end
+
         def call_processor_input(processor, context, input, processors)
           if processor.respond_to?(:processors)
             processor.processors = filter_all_processors(processor.processors)

--- a/lib/sprockets/sass/v4/importer.rb
+++ b/lib/sprockets/sass/v4/importer.rb
@@ -85,7 +85,7 @@ module Sprockets
           end
         end
 
-        def get_engines_from_attributes(_attributes)
+        def get_engines_from_attributes(_context, _attributes)
           []
         end
 

--- a/spec/importer_spec.rb
+++ b/spec/importer_spec.rb
@@ -24,7 +24,7 @@ describe Sprockets::Sass do
     @root.destroy!
   end
 
-  if (3..4).include?(Sprockets::Sass::Utils.version_of_sprockets)
+  if (3...4).include?(Sprockets::Sass::Utils.version_of_sprockets)
     it 'allow calls the get engines from attributes with proper arguments' do
       expect_any_instance_of(@importer_class).to receive(:get_engines_from_attributes).with(anything, [@dep_path.to_s.gsub('.css.xyz', ''), "text/css", [".xyz"], nil]).at_least(:once).and_call_original
       asset = @env['main.css']

--- a/spec/importer_spec.rb
+++ b/spec/importer_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Sprockets::Sass do
+
+
+  before :each do
+    @root = create_construct
+    @assets = @root.directory 'assets'
+    @public_dir = @root.directory 'public'
+    @env = Sprockets::Environment.new @root.to_s
+    @env.append_path @assets.to_s
+    @env.register_postprocessor 'text/css', FailPostProcessor
+    @test_registration = Sprockets::Sass::TestRegistration.new(@env)
+    @test_registration.register_engines('.xyz' =>  Sprockets::Sass::FakeEngine)
+    @importer_class = Sprockets::Sass::Utils.get_class_by_version("Importer")
+  end
+
+  before(:each) do
+    @assets.file 'main.css.scss', %(@import "dep")
+    @dep_path = @assets.file 'dep.css.xyz', "$color: blue;\nbody { color: $color; }"
+  end
+  after :each do
+
+    @root.destroy!
+  end
+
+  if (3..4).include?(Sprockets::Sass::Utils.version_of_sprockets)
+    it 'allow calls the get engines from attributes with proper arguments' do
+      expect_any_instance_of(@importer_class).to receive(:get_engines_from_attributes).with(anything, [@dep_path.to_s.gsub('.css.xyz', ''), "text/css", [".xyz"], nil]).at_least(:once).and_call_original
+      asset = @env['main.css']
+    end
+
+    it 'calls the normalize extension from sprockets utils' do
+      expect(::Sprockets::Utils).to receive(:normalize_extension).with('.xyz').at_least(:once).and_call_original
+      asset = @env['main.css']
+    end
+
+    it 'retursn the engines registered on the file path' do
+      expect_any_instance_of(@importer_class).to receive(:filter_all_processors).with(array_including(Sprockets::Sass::FakeEngine)).at_least(:once).and_call_original
+      asset = @env['main.css']
+    end
+  end
+
+end

--- a/spec/importer_spec.rb
+++ b/spec/importer_spec.rb
@@ -19,8 +19,8 @@ describe Sprockets::Sass do
     @assets.file 'main.css.scss', %(@import "dep")
     @dep_path = @assets.file 'dep.css.xyz', "$color: blue;\nbody { color: $color; }"
   end
-  after :each do
 
+  after :each do
     @root.destroy!
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,15 @@ require 'compass'
 require 'test_construct'
 
 RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec
+  
+  config.include RSpec::Matchers
   config.include TestConstruct::Helpers
 end
 

--- a/spec/sprockets-sass_spec.rb
+++ b/spec/sprockets-sass_spec.rb
@@ -396,7 +396,7 @@ describe Sprockets::Sass do
       expect(res).to  eql("div{color:red}\n")
     end
   end
-  
+
 
   describe Sprockets::Sass::SassTemplate do
 
@@ -410,15 +410,15 @@ describe Sprockets::Sass do
       it 'does add Sass functions if sprockets-helpers is not available' do
         Sprockets::Sass::SassTemplate.sass_functions_initialized = false
         Sprockets::Sass.add_sass_functions = true
-        Sprockets::Sass::SassTemplate.any_instance.should_receive(:require).with('sprockets/helpers').and_raise LoadError
-        Sprockets::Sass::SassTemplate.any_instance.should_not_receive(:require).with 'sprockets/sass/functions'
+        expect_any_instance_of(Sprockets::Sass::SassTemplate).to receive(:require).with('sprockets/helpers').and_raise LoadError
+        expect_any_instance_of(Sprockets::Sass::SassTemplate).to_not receive(:require).with 'sprockets/sass/functions'
         template
         expect(Sprockets::Sass::SassTemplate.engine_initialized?).to be_falsy
       end
 
       it 'does not add Sass functions if add_sass_functions is false' do
         Sprockets::Sass.add_sass_functions = false
-        template.should_not_receive(:require).with 'sprockets/sass/functions'
+        expect(template).to_not receive(:require).with 'sprockets/sass/functions'
         template.initialize_engine
         expect(Sprockets::Sass::SassTemplate.engine_initialized?).to be_falsy
         Sprockets::Sass.add_sass_functions = true

--- a/spec/support/be_fresh_matcher.rb
+++ b/spec/support/be_fresh_matcher.rb
@@ -11,11 +11,11 @@ RSpec::Matchers.define :be_fresh do |env, old_asset|
     end
   end
 
-  failure_message_for_should do |env|
+  failure_message do |env|
     'expected asset to be fresh'
   end
 
-  failure_message_for_should_not do |env|
+  failure_message_when_negated do |env|
     'expected asset to be stale'
   end
 end

--- a/spec/support/fake_engine.rb
+++ b/spec/support/fake_engine.rb
@@ -1,0 +1,50 @@
+module Sprockets
+  module Sass
+    class FakeEngine
+      VERSION = '1'
+
+      def self.default_mime_type
+        'text/xyx'
+      end
+
+      # Public: Return singleton instance with default options.
+      #
+      # Returns SassProcessor object.
+      def self.instance
+        @instance ||= new
+      end
+
+      def self.call(input)
+        instance.call(input)
+      end
+
+      attr_accessor :has_been_used
+      attr_reader :context
+
+      def initialize(*_args, &block)
+        @has_been_used = false
+      end
+
+      def call(input)
+        @context  = input[:environment].context_class.new(input)
+        run
+      end
+
+      def render(context, _empty_hash_wtf)
+        @context = context
+        run
+      end
+
+      def run
+        @has_been_used = true
+        result = ""
+        if context.respond_to?(:metadata)
+          context.metadata.merge(data: result, sass_dependencies:  Set.new([]))
+        else
+          result
+        end
+      end
+
+    end
+  end
+end

--- a/spec/support/test_registration.rb
+++ b/spec/support/test_registration.rb
@@ -1,0 +1,11 @@
+module Sprockets
+  module Sass
+    class TestRegistration < Sprockets::Sass::Registration
+
+      def register_engines(hash)
+        _register_engines(hash)
+      end
+
+    end
+  end
+end

--- a/sprockets-sass.gemspec
+++ b/sprockets-sass.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency             'sprockets',         '>= 2.0', '< 4.0'
 
-  s.add_development_dependency 'rspec',             '~> 2.13'
+  s.add_development_dependency 'rspec',             '~> 3.5'
   s.add_development_dependency 'test_construct',    '~> 2.0'
   s.add_development_dependency 'sprockets-helpers', '~> 1.0'
   s.add_development_dependency 'sass',              '~> 3.3'


### PR DESCRIPTION
This fixes also this https://github.com/petebrowne/sprockets-sass/pull/40 

After some research i found how to detect engines registered on a file extension.

Tested also and works like a charm. 

Apparently it seems i no longer have to delete this line `context.metadata.delete(:data)` from `handle_complex_process_result`. Seems to work just fine with that line too.

Let me know what you think. Thanks. 
